### PR TITLE
Specify flash_size in esp32 section

### DIFF
--- a/esphome.yaml
+++ b/esphome.yaml
@@ -31,11 +31,11 @@ esphome:
       - -Os
       - -Werror=all
     board_build.flash_mode: dio
-    board_upload.flash_size: 16MB
     board_build.partitions: "../../../custom_partitions.csv"
 
 esp32:
   board: esp32-s3-devkitc-1
+  flash_size: 16MB
   framework:
     type: esp-idf
     sdkconfig_options:


### PR DESCRIPTION
This fixes the following error I was getting during compile: 

```
Please specify flash_size within esp32 configuration only
```

Checking the [documentation for esphome](https://esphome.io/components/esp32.html#configuration-variables), I can see that this is expected, and also looks like a recent-ish change that was made in https://github.com/esphome/esphome-docs/pull/3345 (+related PRs)